### PR TITLE
Potential fix for code scanning alert no. 55: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -6,6 +6,8 @@
 # For our project, we generate this file through a build process from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: check dist
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/andykenward/github-actions-cloudflare-pages/security/code-scanning/55](https://github.com/andykenward/github-actions-cloudflare-pages/security/code-scanning/55)

To fix this issue, add a `permissions` block at the top level of the workflow file (.github/workflows/check-dist.yml), right after the `name:` field and before the `on:` field. This block should specify the minimal permissions required for the workflow, which in this case is likely just `contents: read`. None of the workflow steps appear to modify repository content, interact with issues, or require write access anywhere outside artifact upload (which does not require repository write permissions). No imports or other changes are needed; just add the following block:

```yaml
permissions:
  contents: read
```

Add this block after `name: check dist` (line 8).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
