### PR TITLE
ci: pr automation use github app token

### DIFF
--- a/.github/workflows/sync-readme-versions.yml
+++ b/.github/workflows/sync-readme-versions.yml
@@ -38,10 +38,15 @@ jobs:
         run: pnpm run sync:readme
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Commit and push version reference updates
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'docs: update action version references [skip ci]'
           sign-commits: true
           title: 'docs: update action version references'

--- a/.github/workflows/sync-readme-versions.yml
+++ b/.github/workflows/sync-readme-versions.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Commit and push version reference updates
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,11 +32,16 @@ jobs:
         run: pnpm run download
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: update payloads'
           sign-commits: true
           branch: 'chore/update-payloads'
@@ -58,11 +63,16 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
       - name: cli all
         run: pnpm run tsc:types
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: update types'
           sign-commits: true
           branch: 'chore/types'
@@ -92,11 +102,16 @@ jobs:
             | jq -r '.data' \
             > schema/github/schema.graphql
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: update GitHub GraphQL schema'
           sign-commits: true
           branch: 'chore/update-graphql-schema'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
@@ -68,6 +70,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
@@ -107,6 +111,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1


### PR DESCRIPTION
## What

Switch the PR-creating automation workflows from the default `GITHUB_TOKEN` to a GitHub App token (minted via `actions/create-github-app-token`).

Affected:
- `.github/workflows/update.yml` — `download`, `types`, and `schema` jobs
- `.github/workflows/sync-readme-versions.yml` — `sync` job

## Why

PRs (and pushes) created with the repository's `GITHUB_TOKEN` **do not trigger new workflow runs** — this is GitHub's recursion guard:

> "events triggered by the `GITHUB_TOKEN` … will not create a new workflow run"
> — [Trigger a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow)

As a result, the automated payload / types / GraphQL-schema / README-version PRs were opening with **no `test`, `check-dist`, or `zizmor` checks running**, so they could merge unvalidated. Using a GitHub App token makes the bot a distinct actor, so CI runs on the resulting PRs.

## Notes

- Uses the recommended `client-id` input (the legacy `app-id` still works but is deprecated).
- Read-only `GITHUB_TOKEN` uses are intentionally left unchanged: the `pnpm run download` script and the GraphQL-schema `curl` in `update.yml`.
- The new action is SHA-pinned (`bcd2ba4` / `v3.2.0`) to match repo convention.

## Required repo configuration

This will fail until a GitHub App is wired up. Create/install an App with **Contents: read & write** and **Pull requests: read & write**, then add:

- Variable `APP_CLIENT_ID` — the App's Client ID
- Secret `APP_PRIVATE_KEY` — the App's private key (PEM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)