### PR TITLE
ci: changesets release uses github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,17 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-pnpm
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write # push the version/CHANGELOG commit, tags, and GitHub releases
+          permission-pull-requests: write # create/update the Version Packages PR
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b #v1.8.0
         with:
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

Route `changesets/action` through the GitHub App token (the same App added in #769) by setting its `GITHUB_TOKEN` env to `${{ steps.app-token.outputs.token }}`.

## Why

The changesets "Version Packages" PR was created with the default `GITHUB_TOKEN`, so — like the other automation PRs fixed in #769 — it opened with **no CI** (`test`, `check-dist`, `zizmor`):

> "events triggered by the `GITHUB_TOKEN` … will not create a new workflow run"
> — [Trigger a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow)

This is about token **identity**, not permission level — a `GITHUB_TOKEN`-authored PR can't trigger workflows regardless of scopes. Authoring it via the App fixes that, so the release PR (which carries the version bump and `CHANGELOG.md` updates) now runs the actions.

## Notes

- App token is scoped to `contents: write` (push the version/CHANGELOG commit, tags, GitHub releases) and `pull-requests: write` (create/update the Version Packages PR).
- Job-level permissions are unchanged, including `id-token: write` for npm provenance (OIDC trusted publishing).
- Side effect (intended): the `v*` tags pushed at publish time will now trigger `sync-readme-versions`, whose PR is also App-authored (#769) and so will run CI too.
- Requires the same repo config as #769: `APP_CLIENT_ID` (variable) and `APP_PRIVATE_KEY` (secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)