### PR TITLE
ci: workflow consistency tweaks

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: ['**']
+    branches: [main]
 
 # Deny all permissions by default; grant only what's needed per job
 permissions: {}
@@ -20,9 +20,9 @@ jobs:
       actions: read # only needed for private or internal repos
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d #v0.5.6


### PR DESCRIPTION
## What

Small consistency cleanups across workflow triggers and pin comments (item #4 from the workflow review).

## Changes

- **zizmor.yml**
  - `pull_request` now targets `branches: [main]` instead of `['**']`, matching every other workflow. All PRs base on `main`, so this is no behavior change in practice — just consistency.
  - Normalized the two SHA-pin comments from `# vX.Y.Z` to the repo's `#vX.Y.Z` style (these were the only two outliers; the other 23 pins already use no-space).
- **deploy-main.yml** — added `paths-ignore: ['**.md']` to skip docs-only pushes to `main`. Safe here: the deploy target is `example/` (unaffected by repo markdown), and nothing downstream depends on this job running.

## Deliberately *not* changed

`deploy-delete.yml` was also flagged for `paths-ignore`, but adding it would be a **bug**: `deploy.yml` creates a preview deployment for *every* PR (no path filter), so `deploy-delete` must run on every PR close to clean up — including docs-only PRs. A `paths-ignore` there would orphan those previews.

## Notes

- No conflicts with the open App-token (#770) or pnpm-setup (#771) PRs — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)