### PR TITLE
ci: pass app token via changesets/action github-token input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,4 @@ jobs:
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 #v2.1.1
         with:
           publish-script: pnpm release
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The `release` workflow has failed on every run since #845 bumped `changesets/action` from 1.9.0 to 2.1.1 ([run 34268653744](https://github.com/andykenward/github-actions-cloudflare-pages/actions/runs/34268653744)):

> Error: The GITHUB_TOKEN environment variable is set and does not match the "github-token" input. Please pass the custom GitHub token to the "github-token" input and remove the GITHUB_TOKEN environment variable to avoid conflicts.

v2 no longer reads the `GITHUB_TOKEN` environment variable to configure the action. The workflow still supplied the GitHub App token that way, so it conflicted with the `github-token` input's default (the workflow-provided token) and the action bailed out.

## Fix

Pass `steps.app-token.outputs.token` through the `github-token` input and drop the `env` block.

`pnpm release` / `changeset version` still get a token — the action injects `GITHUB_TOKEN` into the child process env from the resolved input ([run.ts#L367](https://github.com/changesets/action/blob/8488615a623b1b9c987934bb89eae8af6a946ac1/src/run.ts#L367)), so `@changesets/changelog-github` keeps working.

## Verification

Not directly verifiable before merge — the `release` workflow only runs on `workflow_run` against `main`. Confirmed against the pinned action's README and source at the pinned SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)