### PR TITLE
ci: ignore vendored repos/ in zizmor and CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: CodeQL config
+
+# Vendored subtrees (e.g. repos/effect) are read-only upstream reference code,
+# not ours to fix. Default setup can't exclude paths, hence advanced setup.
+paths-ignore:
+  - repos
+
+# Match the previous default setup's `remote_and_local` threat model.
+threat-models: local

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 5 * * 1'
+
+# Deny all permissions by default; grant only what's needed per job
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write # upload SARIF to GitHub code scanning
+      contents: read # only needed for private or internal repos
+      actions: read # only needed for private or internal repos
+    strategy:
+      fail-fast: false
+      matrix:
+        # `javascript` covers TypeScript; the names keep the `/language:<x>`
+        # categories the default setup used, so existing alerts carry over.
+        language: [actions, javascript]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 #v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 #v4.37.9
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,9 +28,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # `javascript` covers TypeScript; the names keep the `/language:<x>`
-        # categories the default setup used, so existing alerts carry over.
-        language: [actions, javascript]
+        # Each `category` matches the one the default setup uploaded under,
+        # so existing alerts carry over instead of being duplicated.
+        include:
+          - language: actions
+            category: /language:actions
+          - language: javascript-typescript
+            category: /language:javascript
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
@@ -47,4 +51,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 #v4.37.9
         with:
-          category: /language:${{ matrix.language }}
+          category: ${{ matrix.category }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,3 +26,8 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 #v0.6.1
+        with:
+          # Audit only this repo's own workflows and actions — the default `.`
+          # also collects the vendored repos/ subtrees (e.g. repos/effect/.github/).
+          # zizmor has no path-exclusion setting, so list the inputs instead.
+          inputs: .github action.yml delete/action.yml


### PR DESCRIPTION
## Summary

Stops code scanning from reporting on the vendored `repos/` subtrees (e.g. `repos/effect`, added in #853), which produced 16 zizmor and 8 CodeQL alerts on upstream code we don't maintain.

- **zizmor**: the action's default `.` input walks the whole checkout and collects `repos/effect/.github/workflows/*` and its composite actions. zizmor has no path-exclusion setting, so `inputs` is now an explicit allowlist: `.github action.yml delete/action.yml`.
- **CodeQL**: default setup can't take a config file, so it can't ignore paths. This moves to advanced setup — [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml) + [`.github/codeql/codeql-config.yml`](.github/codeql/codeql-config.yml) with `paths-ignore: [repos]`. It keeps default setup's languages (`actions`, `javascript-typescript`), `/language:actions` and `/language:javascript` categories (set explicitly in the matrix, so existing alerts carry over), weekly schedule, and `remote_and_local` threat model. `github/codeql-action` is pinned to v4.37.9 (v4.38.0 is inside the 7-day Dependabot cooldown).

## ⚠️ Before merging

**Disable CodeQL default setup** (Settings → Code security → CodeQL, or `gh api -X PATCH repos/{owner}/{repo}/code-scanning/default-setup -f state=not-configured`). GitHub rejects advanced-setup results while default setup is enabled, so the new `CodeQL` job fails until it's off.

## Notes

- zizmor's `inputs` is an allowlist — a new top-level action directory must be added to it.
- #853 carries the matching `CLAUDE.md` note listing zizmor among the tools that exclude `repos/`; it applies once that branch rebases onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

