### PR TITLE
ci: comment changeset status on pull requests

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# Comments whether a PR has changesets and what merging it releases.
+# Replaces changeset-bot, which reads only the first 30 changed files and so
+# misses the changesets on large PRs; pr-status diffs with git instead.
+# https://changesets.dev/guide/automating#non-blocking
+name: changeset
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-status:
+    # The Version Packages PR never has changesets.
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      comment-body: ${{ steps.pr-status.outputs.comment-body }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+      - name: Generate PR status
+        id: pr-status
+        uses: changesets/action/pr-status@8488615a623b1b9c987934bb89eae8af6a946ac1 #v2.1.1
+
+  pr-comment:
+    needs: pr-status
+    # Fork and Dependabot PRs get a read-only token on `pull_request`.
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write # create/update the status comment
+    steps:
+      - name: Comment on PR
+        uses: changesets/action/pr-comment@8488615a623b1b9c987934bb89eae8af6a946ac1 #v2.1.1
+        with:
+          body: ${{ needs.pr-status.outputs.comment-body }}

--- a/prek.toml
+++ b/prek.toml
@@ -2,7 +2,9 @@
 # See https://prek.j178.dev for more information.
 #:schema https://www.schemastore.org/prek.json
 
-exclude = "__generated__|.changeset|pnpm-lock.yaml|dist|.devcontainer/devcontainer-lock.json|schema|.agents|.claude"
+# Anchored: an unanchored `.changeset` or `dist` also matches
+# .github/workflows/changeset.yml and check-dist.yml.
+exclude = '^(__generated__|\.changeset|dist|example/dist|schema|\.agents|\.claude)/|^pnpm-lock\.yaml$|^\.devcontainer/devcontainer-lock\.json$'
 
 [[repos]]
 repo = "https://github.com/pre-commit/pre-commit-hooks"


### PR DESCRIPTION
## Summary

- Adds [`changeset.yml`](.github/workflows/changeset.yml), which replaces changeset-bot with [`changesets/action/pr-status` + `pr-comment`](https://changesets.dev/guide/automating#non-blocking) (v2.1.1, the same SHA `release.yml` pins).
- Anchors the `prek.toml` `exclude` regex.

## Why

changeset-bot calls `pulls.listFiles` without pagination, so it only sees a PR's first 30 changed files. On #853 (4,337 files), the 20 added `.changeset/*.md` files come after position 230, so the bot reported "No Changeset found". `pr-status` diffs with git in a temporary worktree, so PR size doesn't matter.

## Notes

- Uses `pull_request`, not the guide's `pull_request_target` (zizmor's dangerous-triggers audit; matches `deploy.yml`). Fork and Dependabot PRs get a read-only token there, so the comment job skips them.
- Least privilege: `pr-status` gets `contents: read`, and only `pr-comment` gets `pull-requests: write`.
- The prek `exclude` patterns were unanchored, so `.changeset`, `dist` and `.claude` also matched `.github/workflows/changeset.yml`, `check-dist.yml` and `claude.yml`, and the hooks skipped them. All three pass with the anchored regex. `example/dist/` stays excluded.
- `effect` also edits the prek `exclude` line (adds `repos`), so expect a one-line conflict there.

## Follow-up

- [x] Uninstall the changeset-bot GitHub App, or PRs get two status comments.
- [ ] This PR should get the new comment ("No changeset found" is expected, since this is a CI-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
