### PR TITLE
docs: help AI agents set up the action in a project

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,7 +31,7 @@ Dual-mode GitHub Action for Cloudflare Pages: **deploy** runs `wrangler pages de
 | `pnpm run format`              | oxfmt (`format:check` to verify)                                                                                           |
 | `pnpm run start`               | Run the built deploy action with `.env` loaded (see `.env.example`)                                                        |
 | `pnpm run act:d`               | Run the delete action locally with `act`                                                                                   |
-| `pnpm run sync:readme`         | Rewrite pinned `@<sha> #vX.Y.Z` refs in READMEs and workflow templates                                                     |
+| `pnpm run sync:readme`         | Rewrite pinned `@<sha> #vX.Y.Z` refs in READMEs, workflow templates and the skill                                          |
 | `pnpm run deployments:delete`  | Delete **all preview** deployments of the `.env` project, bypassing GitHub; repeats until a pass deletes nothing           |
 | `pnpm changeset`               | Record a notable or breaking change for `CHANGELOG.md`                                                                     |
 
@@ -68,6 +68,6 @@ These load automatically when you read a matching file. If one hasn't loaded —
 | [tooling.md](rules/tooling.md)               | `package.json`, TS/lint/format/bundler config, `bin/**`, `.claude/` config, `.devcontainer/**`  | Dependencies, TypeScript 6 + 7, `@effect/tsgo`, scripts, bundling, hooks, debugging  |
 | [workflows.md](rules/workflows.md)           | `.github/**`                                                                                    | CI, release, Dependabot, workflow hygiene, signed bot commits                        |
 | [repos.md](rules/repos.md)                   | `repos/**`, the configs that exclude it, `sync-effect.yml`                                      | Vendored-source exclusions and the snapshot sync                                     |
-| [docs.md](rules/docs.md)                     | READMEs, `CONTRIBUTING.md`, `action.yml`, workflow templates, `.claude/**/*.md`                 | User and contributor docs, Markdown gotchas, maintaining these instructions          |
+| [docs.md](rules/docs.md)                     | READMEs, `CONTRIBUTING.md`, `action.yml`, workflow templates, `skills/**`, `.claude/**/*.md`    | User and contributor docs, Markdown gotchas, maintaining these instructions          |
 
 Record new learnings where they apply: session-wide rules here, path-specific ones in the matching rule.

--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -23,6 +23,8 @@ paths:
   - GitHub Environments must be created manually — the action can't create them (that needs `administration:write`).
   - With `GITHUB_TOKEN`, grant `contents: read`, `deployments: write`, `pull-requests: write`, plus `actions: read` for private repos.
   - Supported events: `push`, `pull_request`, `workflow_dispatch`, `workflow_run`.
+  - A failed or canceled Cloudflare build fails the step, as does one still running after 10 minutes. The outputs and job summary are written first; no pull request comment or GitHub Deployment is created.
+  - The README's Troubleshooting table quotes the actions' exact error messages. Changing a message in `src/` means updating that table, `delete/README.md`'s, and the skill's.
   - A deploy job's `timeout-minutes` must exceed the action's 10-minute polling ceiling plus upload time, or the runner kills the job before the action can report. Agents copy examples verbatim.
   - The deployment payload embeds Cloudflare metadata so the delete action can find deployments (`src/common/github/deployment/types.ts`).
 - **`workflow_run` + fork PRs**: `github.event.workflow_run.pull_requests` is **empty for fork PRs** ([community #25220](https://github.com/orgs/community/discussions/25220)). Never derive `pr-number` or `branch` from `pull_requests[0]` in docs or examples — it silently resolves to empty for exactly the fork case those examples target. Save the number in the triggering `pull_request` workflow and hand it over as an artifact (`upload-artifact` → `download-artifact` with `run-id: ${{ github.event.workflow_run.id }}` + `github-token`). See "Custom branch name" in `README.md`.

--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -14,12 +14,14 @@ paths:
 ## User docs
 
 - `README.md` documents the deploy action; `delete/README.md` the delete action. Adding, changing or removing an input or output — or any user-visible behavior — means updating the matching Inputs/Outputs table and examples.
+- Keep the input and output descriptions in `action.yml` / `delete/action.yml` in step with the README tables — agents and the Marketplace read `action.yml` first. Don't hardcode the default Wrangler version there: `bin/sync-versions.ts` only updates `src/common/inputs.ts`.
 - Never hand-edit the pinned `andykenward/...@<sha> #vX.Y.Z` refs — `bin/sync-readme-versions.ts` (`pnpm run sync:readme`) maintains them.
 - `CONTRIBUTING.md` is for contributors: setup, commands, the pull request checklist and the vendored Effect source. Keep its checklist in step with `.claude/CLAUDE.md` ("Before you finish") and its vendored-source section with `.claude/rules/repos.md`. Keep contributor material out of the READMEs.
 - Facts the docs must get right:
   - GitHub Environments must be created manually — the action can't create them (that needs `administration:write`).
   - With `GITHUB_TOKEN`, grant `contents: read`, `deployments: write`, `pull-requests: write`, plus `actions: read` for private repos.
   - Supported events: `push`, `pull_request`, `workflow_dispatch`, `workflow_run`.
+  - A deploy job's `timeout-minutes` must exceed the action's 10-minute polling ceiling plus upload time, or the runner kills the job before the action can report. Agents copy examples verbatim.
   - The deployment payload embeds Cloudflare metadata so the delete action can find deployments (`src/common/github/deployment/types.ts`).
 - **`workflow_run` + fork PRs**: `github.event.workflow_run.pull_requests` is **empty for fork PRs** ([community #25220](https://github.com/orgs/community/discussions/25220)). Never derive `pr-number` or `branch` from `pull_requests[0]` in docs or examples — it silently resolves to empty for exactly the fork case those examples target. Save the number in the triggering `pull_request` workflow and hand it over as an artifact (`upload-artifact` → `download-artifact` with `run-id: ${{ github.event.workflow_run.id }}` + `github-token`). See "Custom branch name" in `README.md`.
 

--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -6,6 +6,7 @@ paths:
   - 'action.yml'
   - 'delete/action.yml'
   - '.github/workflow-templates/**'
+  - 'skills/**'
   - '.claude/**/*.md'
 ---
 
@@ -15,7 +16,8 @@ paths:
 
 - `README.md` documents the deploy action; `delete/README.md` the delete action. Adding, changing or removing an input or output — or any user-visible behavior — means updating the matching Inputs/Outputs table and examples.
 - Keep the input and output descriptions in `action.yml` / `delete/action.yml` in step with the README tables — agents and the Marketplace read `action.yml` first. Don't hardcode the default Wrangler version there: `bin/sync-versions.ts` only updates `src/common/inputs.ts`.
-- Never hand-edit the pinned `andykenward/...@<sha> #vX.Y.Z` refs — `bin/sync-readme-versions.ts` (`pnpm run sync:readme`) maintains them.
+- Never hand-edit the pinned `andykenward/...@<sha> #vX.Y.Z` refs — `bin/sync-readme-versions.ts` (`pnpm run sync:readme`) maintains them. A new file with pinned refs goes in both its `files` list and the `add-paths` of `.github/workflows/sync-readme-versions.yml`.
+- `skills/github-actions-cloudflare-pages/SKILL.md` is the installable skill for agents setting the action up in other projects (`npx skills add andykenward/github-actions-cloudflare-pages`). Keep it in step with the README's setup, examples and error messages, and link to docs with absolute GitHub URLs — it's installed outside this repo. It must stay the only skill under `skills/`: the `skills` CLI searches the whole repo, including `repos/effect`, when it finds none there. Check what it discovers with `pnpm exec skills add . --list`.
 - `CONTRIBUTING.md` is for contributors: setup, commands, the pull request checklist and the vendored Effect source. Keep its checklist in step with `.claude/CLAUDE.md` ("Before you finish") and its vendored-source section with `.claude/rules/repos.md`. Keep contributor material out of the READMEs.
 - Facts the docs must get right:
   - GitHub Environments must be created manually — the action can't create them (that needs `administration:write`).

--- a/.claude/rules/tooling.md
+++ b/.claude/rules/tooling.md
@@ -39,7 +39,7 @@ paths:
 
 - Prefer `node path/to/script.ts` (native type-stripping, no extra dependency). It works when the script's **runtime** imports are only `node:*`, relative paths, `package.json`, npm packages or **type-only** `@/` aliases (`import type` is erased) — e.g. `node bin/deployments/index.ts`.
 - Use `tsx` for anything that transitively imports `__generated__/gql/` (e.g. `tsx bin/sync-readme-versions.ts`): `graphql.ts` emits `export enum`, which type-stripping rejects, and `gql.ts` has a runtime `import * as types from './graphql.js'` that node won't remap to `.ts`. Neither is fixable — they're generated. `tsx` reads tsconfig paths, transforms enums and remaps extensions; `verbatimModuleSyntax` doesn't change any of this, and `#`-prefixed subpath imports only redirect the entry import.
-- A `bin/` script that is both importable (for tests) and executable wraps side effects in `if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href)` and exports pure functions (reference: `bin/sync-readme-versions.ts`). Its tests go in `__tests__/scripts/`.
+- A `bin/` script that is both importable (for tests) and executable wraps side effects in `if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href)` and exports pure functions (reference: `bin/sync-readme-versions.ts`). Its tests go in `__tests__/scripts/`. To call its exports ad hoc, import them from an `.mts` file run with `tsx` — `tsx -e` evaluates as CommonJS and fails on the script's top-level `await`.
 
 ## Bundling (`esbuild.config.js`)
 

--- a/.claude/rules/workflows.md
+++ b/.claude/rules/workflows.md
@@ -22,7 +22,7 @@ paths:
 - `test.yml` runs only `lint`, `tsc:check` and `test:ci` — not knip, format or codegen drift.
 - `check-dist.yml` rebuilds and fails if the committed `dist/` differs.
 - `prek.yml` runs `prek run --all-files` on PRs and `main`; keep its `prek-version` equal to the prek in `.devcontainer/Dockerfile`.
-- `deploy.yml`, `deploy-main.yml` and `deploy-delete.yml` dogfood the action (`uses: ./`, `./delete`) against `example/`. Only `deploy.yml` skips fork PRs.
+- `deploy.yml`, `deploy-main.yml` and `deploy-delete.yml` dogfood the action (`uses: ./`, `./delete`) against `example/`. Only `deploy.yml` skips fork PRs. Deploy jobs need `timeout-minutes` above the action's 10-minute polling ceiling plus upload time (they use 15); delete jobs don't poll.
 - `codeql.yml` runs CodeQL as advanced setup, because default setup can't exclude `repos/` (`.github/codeql/codeql-config.yml` `paths-ignore`).
 - **Release** (`release.yml`): after `test` passes on `main`, changesets/action opens the "Version Packages" PR; merging it runs `pnpm release` (`pnpm run all && changeset publish`). The package is private, so "publish" means a git tag + GitHub release. A `v*` tag triggers `sync-readme-versions.yml`, which PRs the new pinned SHA into the READMEs and `.github/workflow-templates/`.
 - `update.yml` (weekly) opens PRs refreshing webhook payloads, generated types and the GitHub GraphQL schema.

--- a/.github/workflow-templates/deploy.yml
+++ b/.github/workflow-templates/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       deployments: write
       pull-requests: write
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15 # The action waits up to 10 minutes for Cloudflare.
     steps:
       - name: 'Checkout Github Action'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -20,7 +20,7 @@ jobs:
       deployments: write
       pull-requests: write
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15 # The action waits up to 10 minutes for Cloudflare.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       deployments: write
       pull-requests: write
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15 # The action waits up to 10 minutes for Cloudflare.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:

--- a/.github/workflows/sync-readme-versions.yml
+++ b/.github/workflows/sync-readme-versions.yml
@@ -54,3 +54,4 @@ jobs:
             delete/README.md
             .github/workflow-templates/deploy.yml
             .github/workflow-templates/delete.yml
+            skills/github-actions-cloudflare-pages/SKILL.md

--- a/README.md
+++ b/README.md
@@ -331,6 +331,30 @@ The GitHub Deployment payload this action creates includes the Cloudflare metada
 }
 ```
 
+## Troubleshooting
+
+A failed step's annotation carries a one-line message; turn on [step debug logs](#debugging) for the full error.
+
+| Message                                                                                      | Cause and fix                                                                                                                                                                               |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Input required and not supplied: <input>`                                                   | A required input is empty. Check the secret or variable exists — on a fork's `pull_request` run, secrets are empty, so deploy with [`workflow_run`](#fork-pull-requests-with-workflow_run). |
+| `Input '<input>' is invalid: …`                                                              | The input has the wrong format; the rest of the message says what was expected.                                                                                                             |
+| `GitHub Action event name '<name>' not supported.`                                           | Trigger on one of the [supported events](#supported-events).                                                                                                                                |
+| `GitHub Environment: Not created for <name>`                                                 | The environment doesn't exist — [create it](#2-github-environments-required), or fix the `github-environment` expression.                                                                   |
+| `GitHub Environment: No ref id <name>`                                                       | The branch or tag the run is for no longer exists, e.g. it was deleted before the run started.                                                                                              |
+| `GitHub Environment: Errors - […]`                                                           | GitHub rejected the lookup; the JSON lists its errors. Usually `github-token` is missing a [permission](#3-permissions).                                                                    |
+| `GitHub API request failed: <status> …`                                                      | A 401 or 403 means `github-token` is invalid or missing a [permission](#3-permissions).                                                                                                     |
+| A JSON list of errors mentioning `Resource not accessible by integration`                    | `github-token` is missing a [permission](#3-permissions) — usually `deployments: write` or `pull-requests: write`.                                                                          |
+| `Invalid pr-number input: <value>`                                                           | `pr-number` must be a positive whole number.                                                                                                                                                |
+| `No pull request node id found for pr-number input: <number>`                                | No pull request with that number exists in this repository.                                                                                                                                 |
+| `No pull request node id found for workflow_dispatch event`                                  | No open pull request is headed by the dispatched branch. Dispatch from one, or set `pr-number`.                                                                                             |
+| `No pull request found in workflow_run event matching head branch and sha`                   | The run has no matching pull request — always the case for forks. Set `pr-number` ([example](#custom-branch-name)).                                                                         |
+| `Multiple pull requests found in workflow_run event matching head branch and sha`            | Several pull requests share the commit. Set `pr-number`.                                                                                                                                    |
+| `Status Of Deployment: timed out after 10m waiting for the deploy stage to complete.`        | Cloudflare didn't finish within 10 minutes. Check the build in the Cloudflare dashboard.                                                                                                    |
+| An error printed by Wrangler                                                                 | The upload failed and Wrangler's message says why. Check the token's permission, `cloudflare-account-id`, `cloudflare-project-name` and `directory`.                                        |
+| The job is cancelled at its time limit                                                       | Raise the job's `timeout-minutes` to at least 15 — the action waits up to 10 minutes for Cloudflare.                                                                                        |
+| `Create Deployment: the Cloudflare Pages build failed. Build log: <url>` (or `was canceled`) | The build failed or was canceled on Cloudflare. Open the build log link; the outputs and job summary still describe the deployment.                                                         |
+
 ## Debugging
 
 GitHub provides two debug log levels — see [Action Debugging]. Enable them by [setting a repository secret]:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,13 @@ permissions:
 
 ## Setting up with an AI agent
 
-Adding this action with an AI coding agent? Point it at this section.
+Adding this action with an AI coding agent? Install its skill, which walks the agent through the steps below:
+
+```sh
+npx skills add andykenward/github-actions-cloudflare-pages
+```
+
+Or point the agent at this section.
 
 1. **Do the steps outside the workflow file first** — they can't be expressed in YAML. Run them, or ask the user to:
    - create a Cloudflare Pages project and an API token with the **Cloudflare Pages: Edit** permission;

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ permissions: {}
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15 # The action waits up to 10 minutes for Cloudflare.
     permissions:
       actions: read # Only required for a private repo.
       contents: read
@@ -64,10 +64,27 @@ Create a [Cloudflare Pages] project, then give the action three values (store th
 - `cloudflare-account-id` — your Cloudflare account ID.
 - `cloudflare-project-name` — the Pages project to upload to.
 
+With the [GitHub CLI], run these from your repository — the token is read from a prompt, so it stays out of your shell history:
+
+```sh
+gh secret set CLOUDFLARE_API_TOKEN
+gh variable set CLOUDFLARE_ACCOUNT_ID --body "<account-id>"
+gh variable set CLOUDFLARE_PROJECT_NAME --body "<project-name>"
+```
+
+No Pages project yet? Create one with `npx wrangler pages project create <project-name> --production-branch main`.
+
 ### 2. GitHub Environments (required)
 
 > [!IMPORTANT]
 > This action does **not** create [GitHub Environments]. Creating them requires the GitHub API `administration:write` permission, which the action can't request — so you must create them manually. See [Creating an environment].
+
+To create them with the [GitHub CLI] — this needs admin access to the repository, which your own `gh auth login` session usually has and the workflow's `GITHUB_TOKEN` never does:
+
+```sh
+gh api --method PUT "repos/{owner}/{repo}/environments/production"
+gh api --method PUT "repos/{owner}/{repo}/environments/preview"
+```
 
 Create each environment you reference (for example `production` and `preview`), then select one per run with the `github-environment` input. A common pattern switches on the branch:
 
@@ -106,6 +123,33 @@ permissions:
   pull-requests: write
 ```
 
+## Setting up with an AI agent
+
+Adding this action with an AI coding agent? Point it at this section.
+
+1. **Do the steps outside the workflow file first** — they can't be expressed in YAML. Run them, or ask the user to:
+   - create a Cloudflare Pages project and an API token with the **Cloudflare Pages: Edit** permission;
+   - add the `CLOUDFLARE_API_TOKEN` secret and the `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_PROJECT_NAME` variables;
+   - create every GitHub Environment the workflow names in `github-environment`.
+
+   The commands are in [Setup](#setup).
+
+2. **Pick the workflow** for how the project receives changes:
+
+   | Situation                                                                | Start from                                                                                                                    |
+   | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+   | Pushes to `main`, and pull requests from branches in the same repository | [Quick start](#quick-start)                                                                                                   |
+   | Pull requests from forks                                                 | [Fork pull requests with `workflow_run`](#fork-pull-requests-with-workflow_run) and [Custom branch name](#custom-branch-name) |
+   | Removing preview deployments when a pull request closes                  | The [delete action](./delete/README.md#quick-start)                                                                           |
+
+3. **Fit it to the project:**
+   - Add the project's build step before the deploy step, and set `directory` to its output (relative to `working-directory`).
+   - Keep `uses:` pinned to the full commit SHA shown in these examples.
+   - Use only environment names that exist.
+   - Never build `pr-number` or `branch` from `github.event.workflow_run.pull_requests[0]` — it's empty for pull requests from forks.
+
+4. **Check the first run:** the step's `url` output, the job summary, the pull request comment, and a new deployment under the repository's Environments.
+
 ## How it works
 
 1. **Checks while uploading.** While Wrangler uploads `directory`, the action checks that `github-environment` exists and finds the pull request to comment on. If either fails, the upload is stopped and the step fails straight away, so no orphaned Cloudflare deployment is left behind.
@@ -135,11 +179,11 @@ permissions:
 | `cloudflare-api-token`    | yes      | Cloudflare API token with permission to edit Cloudflare Pages. It's passed only to the Wrangler process and masked in logs, even when it doesn't come from `secrets`.                        |
 | `cloudflare-account-id`   | yes      | Cloudflare account ID.                                                                                                                                                                       |
 | `cloudflare-project-name` | yes      | Cloudflare Pages project to upload to.                                                                                                                                                       |
-| `directory`               | yes      | Directory of static files to upload.                                                                                                                                                         |
+| `directory`               | yes      | Directory of built static files to upload, relative to `working-directory`.                                                                                                                  |
 | `github-token`            | yes      | GitHub token with the [required permissions](#3-permissions). Masked in logs, even when it doesn't come from `secrets`.                                                                      |
 | `github-environment`      | yes      | [GitHub Environment](#2-github-environments-required) to record the deployment in. It must already exist.                                                                                    |
 | `pr-number`               | no       | Pull request number to comment on. If not set, it's detected from the event — see [Which pull request gets the comment](#which-pull-request-gets-the-comment).                               |
-| `working-directory`       | no       | Directory to run Wrangler from.                                                                                                                                                              |
+| `working-directory`       | no       | Directory to run Wrangler from — e.g. where your `functions/` folder lives. Defaults to `.`, the job's working directory.                                                                    |
 | `wrangler-version`        | no       | Wrangler version to run. Defaults to the version this release of the action pins. Versions too old to report the new deployment's id fall back to the most recent deployment for the commit. |
 | `branch`                  | no       | Branch name for the Cloudflare Pages deployment. If not set, it's detected from the GitHub context.                                                                                          |
 
@@ -301,6 +345,7 @@ Upgrading from an older version? Check [CHANGELOG.md](./CHANGELOG.md) for breaki
 - [GitHub Actions variables](https://docs.github.com/en/actions/learn-github-actions/variables) and [default environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
 
 [Cloudflare Pages]: https://pages.cloudflare.com/
+[GitHub CLI]: https://cli.github.com/
 [job summary]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
 [Wrangler]: https://developers.cloudflare.com/workers/wrangler/
 [pull request]: https://docs.github.com/en/pull-requests

--- a/action.yml
+++ b/action.yml
@@ -1,53 +1,53 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-action.json
 
 name: 'GitHub Action for Cloudflare Pages'
-description: 'Deploy to Cloudflare Pages'
+description: 'Deploy to Cloudflare Pages with Wrangler, record a GitHub Deployment, and comment the preview URL on the pull request'
 branding:
   icon: 'upload-cloud'
   color: 'orange'
 inputs:
   cloudflare-api-token:
-    description: 'Cloudflare API Token'
+    description: 'Cloudflare API token with the Cloudflare Pages Edit permission. Pass it from a secret; it is masked in logs.'
     required: true
   cloudflare-account-id:
-    description: 'Cloudflare Account ID'
+    description: 'Cloudflare account ID'
     required: true
   cloudflare-project-name:
-    description: 'Cloudflare Pages project name to upload to'
+    description: 'Name of the existing Cloudflare Pages project to upload to'
     required: true
   directory:
-    description: 'Directory of static files to upload'
+    description: 'Directory of built static files to upload, relative to working-directory'
     required: true
   github-token:
-    description: 'Github API key'
+    description: 'GitHub token. With GITHUB_TOKEN, grant contents: read, deployments: write and pull-requests: write (plus actions: read for private repositories).'
     required: true
   github-environment:
-    description: 'GitHub environment to deploy to. You need to manually create this for the github repo'
+    description: 'Existing GitHub Environment to record the deployment in, e.g. production or preview. The action cannot create it: create it in the repository settings first.'
     required: true
   pr-number:
-    description: 'GitHub pull request number to comment on. If not set, the action auto-detects from the event payload.'
+    description: 'Pull request number to comment on. If not set, it is detected from the event; for workflow_dispatch and workflow_run the step fails when no pull request matches. Set it for pull requests from forks under workflow_run.'
     required: false
   working-directory:
-    description: 'Directory to run wrangler cli from'
+    description: 'Directory to run Wrangler from, e.g. where your functions folder lives. Defaults to the job working directory.'
     required: false
   wrangler-version:
-    description: 'Wrangler version to use. Otherwise a default version from the action will be used.'
+    description: 'Wrangler version to run with npx. Defaults to the version this release of the action pins.'
     required: false
   branch:
-    description: 'Branch name to use for Cloudflare Pages deployment. If not set, the branch is automatically detected from the GitHub context.'
+    description: 'Branch name for the Cloudflare Pages deployment, which decides production or preview. Defaults to the branch from the GitHub context.'
     required: false
 
 outputs:
   id:
-    description: 'Cloudflare Pages deployed id'
+    description: 'Cloudflare Pages deployment ID'
   url:
-    description: 'Cloudflare Pages deployed url'
+    description: 'Cloudflare Pages deployment URL'
   environment:
-    description: 'Cloudflare Pages deployed environment "production" or "preview"'
+    description: 'Cloudflare Pages environment of the deployment: production or preview'
   alias:
-    description: 'Cloudflare Pages deployed alias. Fallsback to deployed url if deployed alias is null'
+    description: 'Branch alias URL of the deployment, or its URL when there is no alias'
   wrangler:
-    description: 'Wrangler cli output'
+    description: 'Wrangler CLI output'
 
 runs:
   using: node24

--- a/bin/sync-readme-versions.ts
+++ b/bin/sync-readme-versions.ts
@@ -104,7 +104,8 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
     path.join(root, 'README.md'),
     path.join(root, 'delete', 'README.md'),
     path.join(root, '.github', 'workflow-templates', 'deploy.yml'),
-    path.join(root, '.github', 'workflow-templates', 'delete.yml')
+    path.join(root, '.github', 'workflow-templates', 'delete.yml'),
+    path.join(root, 'skills', 'github-actions-cloudflare-pages', 'SKILL.md')
   ]
 
   for (const filePath of files) {

--- a/delete/README.md
+++ b/delete/README.md
@@ -61,10 +61,10 @@ permissions:
 
 | Input                  | Required | Default | Description                                                                                                                              |
 | ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `cloudflare-api-token` | yes      | —       | Cloudflare API Token.                                                                                                                    |
-| `github-token`         | yes      | —       | Github API key, make sure to add the required permissions for this action.                                                               |
+| `cloudflare-api-token` | yes      | —       | Cloudflare API token with the **Cloudflare Pages: Edit** permission. Masked in logs, even when it doesn't come from `secrets`.           |
+| `github-token`         | yes      | —       | GitHub token with the [required permissions](#permissions). Masked in logs, even when it doesn't come from `secrets`.                    |
 | `github-environment`   | no       | —       | GitHub environment to delete deployments from. Leave undefined to delete all deployments referencing the current branch or pull_request. |
-| `keep-latest`          | no       | `0`     | How many deployments to keep. Default is 0.                                                                                              |
+| `keep-latest`          | no       | `0`     | Number of the newest deployments to keep. `0` deletes them all.                                                                          |
 
 ## Examples
 

--- a/delete/README.md
+++ b/delete/README.md
@@ -66,6 +66,17 @@ permissions:
 | `github-environment`   | no       | —       | GitHub environment to delete deployments from. Leave undefined to delete all deployments referencing the current branch or pull_request. |
 | `keep-latest`          | no       | `0`     | Number of the newest deployments to keep. `0` deletes them all.                                                                          |
 
+## Troubleshooting
+
+| Message                                                                                 | Cause and fix                                                                                                                 |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `delete - <n> of <total> deployments failed to delete; see the job summary for details` | Some deletions failed. The job summary's Error column says why for each one — see the rows below.                             |
+| `Payload is not valid` (in the job summary)                                             | The deployment wasn't created by the deploy action, or its payload was changed. This action only deletes its own deployments. |
+| `Deleting Cloudflare deployment failed` (in the job summary)                            | Cloudflare refused the deletion. Check `cloudflare-api-token` has the **Cloudflare Pages: Edit** permission on the account.   |
+| `Updating GitHub deployment status failed` (in the job summary)                         | GitHub refused the status change. Check `github-token` has `deployments: write`.                                              |
+
+Errors about inputs or the GitHub API read the same as the deploy action's — see its [Troubleshooting](../README.md#troubleshooting).
+
 ## Examples
 
 A ready-to-use template lives at [.github/workflow-templates/delete.yml](../.github/workflow-templates/delete.yml); the [Quick start](#quick-start) above is the same workflow.

--- a/delete/action.yml
+++ b/delete/action.yml
@@ -1,22 +1,22 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-action.json
 
 name: 'GitHub Action for Cloudflare Pages Delete'
-description: 'Delete Deployments to Cloudflare Pages using "andykenward/github-actions-cloudflare-pages"'
+description: 'Delete Cloudflare Pages deployments, with their GitHub Deployments and pull request comments, created by andykenward/github-actions-cloudflare-pages'
 branding:
   icon: 'delete'
   color: 'orange'
 inputs:
   cloudflare-api-token:
-    description: 'Cloudflare API Token'
+    description: 'Cloudflare API token with the Cloudflare Pages Edit permission. Pass it from a secret; it is masked in logs.'
     required: true
   github-token:
-    description: 'Github API key'
+    description: 'GitHub token. With GITHUB_TOKEN, grant contents: read, deployments: write and pull-requests: write (plus actions: read for private repositories).'
     required: true
   github-environment:
-    description: 'GitHub environment to delete deployments from. If not defined any deployments link to the branch/pr are deleted.'
+    description: 'GitHub Environment to delete deployments from. If not set, deletes every deployment for the current branch or pull request.'
     required: false
   keep-latest:
-    description: 'How many deployments to keep. Default is 0.'
+    description: 'Number of the newest deployments to keep. Defaults to 0, which deletes them all.'
     default: '0'
     required: false
 

--- a/skills/github-actions-cloudflare-pages/SKILL.md
+++ b/skills/github-actions-cloudflare-pages/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: github-actions-cloudflare-pages
+description: Set up the andykenward/github-actions-cloudflare-pages GitHub Action to deploy a site to Cloudflare Pages — production deploys from the default branch, preview deploys with a pull request comment, fork-safe workflow_run deploys, and cleanup with its delete action. Use when adding, fixing or reviewing a GitHub Actions workflow that deploys to Cloudflare Pages with this action.
+---
+
+# Deploy to Cloudflare Pages with andykenward/github-actions-cloudflare-pages
+
+Full docs: [README](https://github.com/andykenward/github-actions-cloudflare-pages#readme) · [delete action](https://github.com/andykenward/github-actions-cloudflare-pages/blob/main/delete/README.md) · [action.yml](https://github.com/andykenward/github-actions-cloudflare-pages/blob/main/action.yml)
+
+## 1. Learn the project
+
+- The build command and its output directory → `directory`. If Pages Functions live in a subfolder (`functions/` not at the repo root), that folder → `working-directory`, and `directory` is relative to it.
+- The default branch → the production branch.
+- Whether pull requests come from forks. Forks need the `workflow_run` variant (step 3).
+- The Cloudflare account ID and Pages project name — ask the user if they aren't in the repo.
+
+## 2. Do the steps outside the workflow file
+
+These can't be expressed in YAML. Run them, or ask the user to — they need admin access to the repository:
+
+```sh
+# Only if there is no Pages project yet.
+npx wrangler pages project create <project-name> --production-branch <default-branch>
+
+# The token needs the "Cloudflare Pages: Edit" permission. gh prompts for it —
+# never ask the user to paste the token into the conversation.
+gh secret set CLOUDFLARE_API_TOKEN
+gh variable set CLOUDFLARE_ACCOUNT_ID --body "<account-id>"
+gh variable set CLOUDFLARE_PROJECT_NAME --body "<project-name>"
+
+# The action can't create GitHub Environments, and a missing one fails the run.
+gh api --method PUT "repos/{owner}/{repo}/environments/production"
+gh api --method PUT "repos/{owner}/{repo}/environments/preview"
+```
+
+## 3. Write the workflow
+
+Save as `.github/workflows/cloudflare-pages.yml`. Replace `main` with the default branch (in `on:` and in `github-environment`), add the build steps, and set `directory`:
+
+```yaml
+name: Cloudflare Pages Deploy
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15 # The action waits up to 10 minutes for Cloudflare.
+    permissions:
+      actions: read # Only required for a private repo.
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      # Install dependencies and build the site here, e.g. `npm ci && npm run build`.
+      - name: Deploy to Cloudflare Pages
+        uses: andykenward/github-actions-cloudflare-pages@46d86e1caa6b86365a41d335db65a6936a1beb39 #v3.5.0
+        with:
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          cloudflare-project-name: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+          directory: dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-environment: ${{ (github.ref == 'refs/heads/main' && 'production') || 'preview' }}
+```
+
+**Pull requests from forks**: fork runs get no secrets, so deploy from a second workflow triggered by `workflow_run`. Follow the README's [fork example](https://github.com/andykenward/github-actions-cloudflare-pages#fork-pull-requests-with-workflow_run) and [custom branch name](https://github.com/andykenward/github-actions-cloudflare-pages#custom-branch-name): save the PR number as an artifact in the `pull_request` workflow, then pass it to `pr-number` and `branch: pr-<number>`.
+
+**Cleanup**: to delete a pull request's preview deployments when it closes, add a second workflow:
+
+```yaml
+name: Cloudflare Pages Delete
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read # Only required for a private repo.
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: andykenward/github-actions-cloudflare-pages/delete@46d86e1caa6b86365a41d335db65a6936a1beb39 #v3.5.0
+        with:
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Rules
+
+- Keep `uses:` pinned to a full commit SHA with its `#vX.Y.Z` comment. To upgrade, find the latest release with `gh release view --repo andykenward/github-actions-cloudflare-pages --json tagName`, then its commit with `gh api repos/andykenward/github-actions-cloudflare-pages/commits/<tag> --jq .sha`.
+- Trigger only on `push`, `pull_request`, `workflow_dispatch` or `workflow_run` — any other event fails the step.
+- Never build `pr-number` or `branch` from `github.event.workflow_run.pull_requests[0]`: it is empty for pull requests from forks.
+- For `workflow_dispatch` and `workflow_run`, the step fails when no pull request matches. Set `pr-number`, or use `push` if a comment isn't wanted.
+- Use only `github-environment` names that exist, and keep `timeout-minutes` at 15 or more.
+- Cloudflare decides production vs preview from the branch, not from `github-environment` — the project's production branch must be the one mapped to `production`.
+
+## Verify
+
+After the first run (`gh run watch`), check:
+
+- the step's `url` output and the job summary;
+- the pull request comment, for pull request runs;
+- a new deployment in the repository's Environments (`gh api "repos/{owner}/{repo}/deployments" --jq '.[0]'`).
+
+## Troubleshooting
+
+| Log message                                                                | Fix                                                                                               |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `Input required and not supplied: <input>`                                 | Set the input. On a fork's `pull_request` run secrets are empty — use the `workflow_run` variant. |
+| `GitHub Environment: Not created for <name>`                               | Create the environment (step 2), or fix the `github-environment` expression.                      |
+| `GitHub Action event name '<name>' not supported.`                         | Trigger on `push`, `pull_request`, `workflow_dispatch` or `workflow_run`.                         |
+| `No pull request found in workflow_run event matching head branch and sha` | A fork or branch with no pull request — pass `pr-number` (see the fork example).                  |
+| `No pull request node id found for workflow_dispatch event`                | Dispatch from a branch with an open pull request, or set `pr-number`.                             |
+| `… waiting for the deploy stage to complete`                               | Cloudflare didn't finish within 10 minutes — check the build in the Cloudflare dashboard.         |
+| The job is cancelled at its time limit                                     | Raise `timeout-minutes` to at least 15.                                                           |

--- a/skills/github-actions-cloudflare-pages/SKILL.md
+++ b/skills/github-actions-cloudflare-pages/SKILL.md
@@ -121,6 +121,8 @@ After the first run (`gh run watch`), check:
 
 ## Troubleshooting
 
+A failed or canceled Cloudflare build fails the step with `Create Deployment: the Cloudflare Pages build failed. Build log: <url>` — open that link for Cloudflare's build output. The full list of messages is in the [README](https://github.com/andykenward/github-actions-cloudflare-pages#troubleshooting).
+
 | Log message                                                                | Fix                                                                                               |
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `Input required and not supplied: <input>`                                 | Set the input. On a fork's `pull_request` run secrets are empty — use the `workflow_run` variant. |


### PR DESCRIPTION
## Summary

Makes the published action easier for AI coding agents to set up in someone else's project. **Stacked on #853** (base `effect`); retarget to `main` once #853 merges.

- **Setting up with an AI agent** (README): what to do outside the workflow file first, which workflow to start from, the rules that trip agents up, and how to check the first run. `gh` / `wrangler` commands for the manual steps: secrets, variables, the Pages project and GitHub Environments.
- **Installable skill** — `skills/github-actions-cloudflare-pages/SKILL.md`, installed with `npx skills add andykenward/github-actions-cloudflare-pages`. `sync:readme` now keeps its pinned `uses:` refs current. It is the only skill under `skills/`, so the `skills` CLI no longer offers the vendored Effect skills.
- **`action.yml` descriptions** (both actions), which agents and the Marketplace read first. They now name the token permissions, defaults and failure cases, and fix the "Fallsback" typo. Inputs, outputs, defaults and `required` are unchanged.
- **Troubleshooting tables** (README, delete README, skill) keyed by the actions' exact error messages. Every quoted message was checked against `src/`.
- **Deploy jobs get `timeout-minutes: 15`** (README, workflow template, this repo's deploy workflows). The action waits up to 10 minutes for Cloudflare, so the old 5-minute limit could kill a slow deploy.
- **Failed builds:** #853 now fails the step when a Cloudflare build fails or is canceled, after writing the outputs and job summary, and with no PR comment or GitHub Deployment. `effect` is merged in, so the docs here describe that, and the troubleshooting tables cover its `Create Deployment: the Cloudflare Pages build failed. Build log: <url>` message.
- `.claude/` rules updated to keep the above in step.

## Test plan

- [x] prek (formatting, lint, YAML) and zizmor pass on the changed files
- [x] `pnpm run tsc:check` passes
- [x] `pnpm exec skills add . --list` finds only `github-actions-cloudflare-pages`
- [x] `replaceVersionReferences` rewrites both pinned refs in the skill
- [x] Links and in-page anchors in both READMEs resolve
- [ ] After merge to `main`: `npx skills add andykenward/github-actions-cloudflare-pages` installs the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)